### PR TITLE
remocon get and put now work in symmetry

### DIFF
--- a/remocon
+++ b/remocon
@@ -121,9 +121,9 @@ rbc() {
     esac
 }
 
-# a handy way to patch remote
-# See: https://github.com/netj/bpm/blob/master/plugin/git-helper
-git-tether-remote() {
+# how to duplicate one git worktree to another
+# Origin: https://github.com/netj/bpm/blob/master/plugin/git-helper
+remocon.dup() {
     (
     set -euo pipefail
     hostpath=$1; shift
@@ -290,8 +290,7 @@ remocon.put() {
     [[ $# -eq 0 ]] || error "Cannot put partial changes under given paths: $(@q "$@")"
     # TODO accept multiple remotes as args
     info "🛰 [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
-    git-tether-remote "$remote_host:$remote_repo"
-    # TODO rename git-tether-remote to remocon.dup
+    remocon.dup "$remote_host:$remote_repo"
     # TODO remocon.dup $local_hostrepo $remote_hostrepo
 } </dev/null >&2
 

--- a/remocon
+++ b/remocon
@@ -122,6 +122,7 @@ git-tether-remote() {
     (
     set -euo pipefail
     hostpath=$1; shift
+    # TODO src_hostpath and dst_hostpath
     case $hostpath in
         (*:*) host=${hostpath%%:*} dir=${hostpath#*:};;
         (*) error "$hostpath: HOST[:PATH] required";;
@@ -130,6 +131,7 @@ git-tether-remote() {
     branch=$(git symbolic-ref --short HEAD)
     x git remote add remocon/remote "$host:$dir" 2>/dev/null ||
         x git remote set-url remocon/remote "$host:$dir"
+    # TODO pull if dst is localhost
     x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
         _remocon_git_init() {
             # set -x
@@ -283,8 +285,11 @@ remocon.set() {
 remocon.put() {
     [[ $# -eq 0 ]] || error "Cannot put partial changes under given paths: $(@q "$@")"
     # TODO accept multiple remotes as args
+    # TODO move emojis to the beginning
     info "[$remote_host:$remote_repo/] 🛰 putting a replica of local git work tree on remote"
     git-tether-remote "$remote_host:$remote_repo"
+    # TODO src_hostpath and dst_hostpath
+    # TODO rename git-tether-remote to remocon.dup
 } </dev/null >&2
 
 # put and run given command on remote from the same workdir relative to the git top-level (AKA git prefix)

--- a/remocon
+++ b/remocon
@@ -311,13 +311,7 @@ remocon._parse_config() {
     [[ -n ${remote:=} || ${1:-} = set ]] || error "No remote configured. Please run: remocon set"
 
     # parse remote
-    local remote_repo_root
-    remote_host="${remote%%:*}"
-    remote_repo_root=${remote#$remote_host}
-    remote_repo_root=${remote_repo_root#:}
-
-    # use local git work tree's basename and keep it under given remote_repo_root dir
-    remote_repo=${remote_repo_root:+$remote_repo_root/}$(basename "$(git rev-parse --show-toplevel)")
+    remocon._parse_remote
 
     # determine remote workdir based on where in the git repo we're in
     local local_path_to_git_top local_path_within_git
@@ -355,6 +349,16 @@ remocon._setup_ssh_booster() {
     echo 'export PATH='"$(@q "$sshBoosterRoot"/bin)"':"$PATH"'
 } </dev/null
 
+remocon._parse_remote() {
+    # sets $remote_host and $remote_repo for given $remote
+    : ${local_repo_basename:=$(basename "$(git rev-parse --show-toplevel)")}
+    remote_host="${remote%%:*}"
+    local remote_repo_root
+    remote_repo_root=${remote#$remote_host}
+    remote_repo_root=${remote_repo_root#:}
+    # use local git work tree's basename and keep it under given remote_repo_root dir
+    remote_repo="${remote_repo_root:+$remote_repo_root/}$local_repo_basename"
+}
 
 ################################################################################
 # sub-commands
@@ -383,12 +387,21 @@ remocon.set() {
     printf >>~/.remocon.conf 'remote=%q\n' "$remote"
 }
 
-# tether remote git repo to local one
+# tether remote git repo(s) to local one
 remocon.put() {
-    [[ $# -eq 0 ]] || error "Cannot put partial changes under given paths: $(@q "$@")"
-    # TODO accept multiple remotes as args
-    info "⏫ [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
-    remocon.dup "$remote_host:$remote_repo"
+    : ${remocon_put_keep_going:=false}
+    [[ $# -gt 0 ]] || set -- "$remote"
+    local num_put_failed=0
+    for remote; do
+        remocon._parse_remote
+        info "⏫ [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
+        remocon.dup "$remote_host:$remote_repo" ||
+            if $remocon_put_keep_going
+            then let ++num_put_failed
+            else false
+            fi
+    done
+    return $num_put_failed
 } </dev/null >&2
 
 # put and run given command on remote from the same workdir relative to the git top-level (AKA git prefix)

--- a/remocon
+++ b/remocon
@@ -396,6 +396,7 @@ remocon.prg() {
             *) pathsToPull+=("$arg")
         esac
     done
+    # TODO require a non-empty pathsToPull or default to .
 
     # run command if any were given (after a dash-dash)
     local exitStatus=0

--- a/remocon
+++ b/remocon
@@ -291,8 +291,8 @@ remocon.put() {
     # TODO accept multiple remotes as args
     info "🛰 [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
     git-tether-remote "$remote_host:$remote_repo"
-    # TODO src_hostpath and dst_hostpath
     # TODO rename git-tether-remote to remocon.dup
+    # TODO remocon.dup $local_hostrepo $remote_hostrepo
 } </dev/null >&2
 
 # put and run given command on remote from the same workdir relative to the git top-level (AKA git prefix)
@@ -310,6 +310,7 @@ remocon.run() {
 remocon.get() {
     [[ $# -gt 0 ]] || set -- .
     info "💎 [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
+    # TODO remocon.dup $remote_hostrepo $local_hostrepo
     # TODO use git in case rsync is not available?
     x rsync \
         --verbose \

--- a/remocon
+++ b/remocon
@@ -109,11 +109,12 @@ mkdelegate() {
 
 # remote bash call -- run on given remote host:workdir given bash function, sending variable and function declarations
 rbc() {
-    local hostworkdir=$1; shift
-    local fn=$1; shift
-    case $hostworkdir in
-        (*:*) host=${hostworkdir%%:*} workdir=${hostworkdir#*:};;
-        (*) error "$hostworkdir: HOST[:PATH] required";;
+    local _rbc_hostworkdir=$1; shift
+    local _rbc_fn=$1; shift
+    local _rbc_host _rbc_workdir
+    case $_rbc_hostworkdir in
+        (*:*) _rbc_host=${_rbc_hostworkdir%%:*} _rbc_workdir=${_rbc_hostworkdir#*:};;
+        (*) error "$_rbc_hostworkdir: HOST[:PATH] required";;
     esac
     # prepare command sequence from given function, variable names
     ! [[ -t 1 ]] || : ${force_color:=true}
@@ -121,38 +122,39 @@ rbc() {
         error warning info \
         rbc x x_prefix_for_remote @q declarationsFor in_full_tty cmdseq \
         "$@"
-    set -- "$@" "$fn"  # adding some core names to include
-    local decls
-    decls=$(declarationsFor "$@")
+    set -- "$@" "$_rbc_fn"  # adding some core names to include
+    local _rbc_decls
+    _rbc_decls=$(declarationsFor "$@")
     set -- \
         "set -eu" \
         "cd" \
-        "mkdir -p $(@q "$workdir")" \
-        "cd $(@q "$workdir")" \
-        "PS4=$(@q "$(x_prefix_for_remote "$hostworkdir")")" \
-        "$decls" \
-        "$fn"
+        "mkdir -p $(@q "$_rbc_workdir")" \
+        "cd $(@q "$_rbc_workdir")" \
+        "PS4=$(@q "$(x_prefix_for_remote "$_rbc_hostworkdir")")" \
+        "$_rbc_decls" \
+        "$_rbc_fn"
     # determine how to run the function
+    local _rbc_ssh_opts _rbc_bash_opts
+    _rbc_ssh_opts=(
+    )
+    _rbc_bash_opts=(
+        bash
+    )
     if in_full_tty; then
         # when stdin/out/err is a fully functional terminal
-        ssh_opts+=(-t)   # ask ssh for tty
-        bash_opts+=(-i)  # ask bash for an interactive shell
+        _rbc_ssh_opts+=(-t)   # ask ssh for tty
+        _rbc_bash_opts+=(-i)  # ask bash for an interactive shell
     fi
-    set -- "${bash_opts[@]}" -c "$(cmdseq "$@")"
-    case $host in
+    set -- "${_rbc_bash_opts[@]}" -c "$(cmdseq "$@")"
+    case $_rbc_host in
         localhost)  # special case: run it directly if on same host
             "$@"
             ;;
         *)  # send it over to remote via ssh by default
-            ssh "$host" "${ssh_opts[@]:---}" "$(@q "$@")"
+            ssh "$_rbc_host" "${_rbc_ssh_opts[@]:---}" "$(@q "$@")"
             ;;
     esac
 }
-ssh_opts=(
-)
-bash_opts=(
-    bash
-)
 declarationsFor() {
     while [[ $# -gt 0 ]]; do
         if declare -F "$1" &>/dev/null; then
@@ -179,24 +181,31 @@ remocon.dup() {
     esac
     ########################################
     # ensure destination git clone has the source's commit
+    _remocon_read_git_HEAD() {
+        commit=$(git rev-parse HEAD)
+        branch=$(git symbolic-ref --short HEAD)
+        declare -p commit branch
+    }
+    local commit branch
+    eval "$(rbc "$src_hostpath" _remocon_read_git_HEAD)"
     _remocon_git_init() {
         # set -x
         [[ -e .git ]] || x git init
         # lift some git config to allow push
         x git config receive.denyCurrentBranch ignore
     }
-    # TODO wrap below in a rbc "$src_hostpath"
-    commit=$(git rev-parse HEAD)
-    branch=$(git symbolic-ref --short HEAD)
-    x git remote add remocon/remote "$host:$dir" 2>/dev/null ||
-        x git remote set-url remocon/remote "$host:$dir"
-    # TODO pull if dst is localhost
-    x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
-        rbc "$dst_hostpath" _remocon_git_init
-        x git push -f remocon/remote HEAD:"$branch"
+    _remocon_git_push() {
+        x git remote add remocon/remote "$host:$dir" 2>/dev/null ||
+            x git remote set-url remocon/remote "$host:$dir"
+        x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
+            rbc "$dst_hostpath" _remocon_git_init
+            x git push -f remocon/remote HEAD:"$branch"
+        }
+        # TODO transfer git config to destination
+        git remote remove remocon/remote
     }
-    # TODO transfer git config to destination
-    git remote remove remocon/remote
+    # TODO pull if dst is localhost
+    rbc "$src_hostpath" _remocon_git_push host dir dst_hostpath branch _remocon_git_init
     ########################################
     _actually_rm_files_deleted_from_git_index_that_come_from() {
         local commit=$1; shift

--- a/remocon
+++ b/remocon
@@ -375,7 +375,7 @@ remocon.rec() {
     bash_opts+=(-l)
 
     _remocon_start_tmux_window() {
-        if [[ $(tmux list-sessions | wc -l) -eq 0 ]]
+        if [[ $(tmux list-sessions 2>/dev/null | wc -l) -eq 0 ]]
         then x tmux new-session -d
         else x tmux new-window
         fi

--- a/remocon
+++ b/remocon
@@ -120,13 +120,9 @@ git-tether-remote() {
     esac
     commit=$(git rev-parse HEAD)
     branch=$(git symbolic-ref --short HEAD)
-    bash_remotely() {
-        local script=$1; shift
-        ssh "$host" "$(@q bash -euc "PS4='++ '; $script" "$@")"
-    }
-    git remote add remocon/remote "$host:$dir" 2>/dev/null ||
-        git remote set-url remocon/remote "$host:$dir"
-    git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
+    x git remote add remocon/remote "$host:$dir" 2>/dev/null ||
+        x git remote set-url remocon/remote "$host:$dir"
+    x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
         _remocon_git_init() {
             # set -x
             [[ -e .git ]] || git init
@@ -139,51 +135,52 @@ git-tether-remote() {
     # TODO transfer git config to destination
     git remote remove remocon/remote
     # bring destination to the current commit
-    command-that-actually-rm-files-deleted-from-git-index-that-come-from() {
+    _actually_rm_files_deleted_from_git_index_that_come_from() {
         local commit=$1; shift
-        echo "comm -12 <(git ls-tree -r --name-only $(@q "$commit") | sort) <(git ls-files --others --exclude-standard | sort) | tr '\\n' '\\0' | xargs -0 rm -f"
+        comm -12 <(git ls-tree -r --name-only "$commit" | sort) <(git ls-files --others --exclude-standard | sort) |
+        tr '\n' '\0' | xargs -0 rm -f
     }
-    bash_remotely "# set -x
-        cd $(@q "$dir")
-        branch=$(@q "$branch")
-        commit=$(@q "$commit")
+    local patch=.git/tethered.patch
+    _remocon_reset_to_HEAD() {
+        # set -x
         # reverse any previous patch for tethering
-        if [[ -s .git/tethered.patch ]]; then
-            git apply --binary -R <.git/tethered.patch || git stash
-            mv -f .git/tethered.patch{,~}
+        if [[ -s "$patch" ]]; then
+            git apply --binary -R <"$patch" || git stash
+            mv -f "$patch"{,~}
         fi
         if git rev-parse HEAD &>/dev/null; then
             # preserve any outstanding/untethered changes
             git diff --quiet --exit-code HEAD -- || git stash
             # make sure we're on the tethered branch and commit
-            [[ \$(git symbolic-ref --short HEAD) = \$branch ]] || git checkout -f \$branch --
+            [[ $(git symbolic-ref --short HEAD) = $branch ]] || git checkout -f $branch --
         else
             # no branch was checked out before
-            git checkout -f \$branch --
+            git checkout -f $branch --
         fi
-        git reset --hard \$commit
-        $(command-that-actually-rm-files-deleted-from-git-index-that-come-from "HEAD@{1}")  # (necessary as git-reset does not always handle delete files cleanly)
-    "
+        git reset --hard $commit
+        _actually_rm_files_deleted_from_git_index_that_come_from HEAD@{1}  # (necessary as git-reset does not always handle delete files cleanly)
+    }
+    rbc "$hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
     # send staged and unstaged changes
-    git diff --full-index --binary HEAD |
-    bash_remotely "cat >$(@q "$dir")/.git/tethered.patch"
-    bash_remotely "# set -x
-        cd $(@q "$dir")
+    _remocon_write_patch() { tee "$patch" >/dev/null; }
+    x git diff --full-index --binary HEAD | rbc "$hostpath" _remocon_write_patch patch
+    _remocon_apply_patch() {
         # with the same outstanding changes on top of the current commit
-        ! [[ -s .git/tethered.patch ]] || git apply --binary --apply --stat --cached <.git/tethered.patch
+        ! [[ -s "$patch" ]] || git apply --binary --apply --stat --cached <"$patch"
         # (relying on git-checkout from current git index takes care of a lot, such as permissions, symlinks)
         git checkout --quiet .
         # (however, git-checkout does not handle deleted files nicely, so ensuring any files in HEAD that fell into --others are removed)
-        $(command-that-actually-rm-files-deleted-from-git-index-that-come-from "HEAD")
-        "
+        _actually_rm_files_deleted_from_git_index_that_come_from HEAD
+    }
+    rbc "$hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
     # replicate staged changes AKA .git/index
-    git diff --full-index --binary --cached |
-    bash_remotely "cat >$(@q "$dir")/.git/tethered-index.patch"
-    bash_remotely "# set -x
-        cd $(@q "$dir")
+    x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch
+    local patch=.git/tethered-index.patch
+    _remocon_apply_patch_index() {
         git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
-        ! [[ -s .git/tethered-index.patch ]] || git apply --binary --apply --cached <.git/tethered-index.patch
-        "
+        ! [[ -s "$patch" ]] || git apply --binary --apply --cached <"$patch"
+    }
+    rbc "$hostpath" _remocon_apply_patch_index patch
     )
 }
 

--- a/remocon
+++ b/remocon
@@ -93,9 +93,12 @@ rbc() {
         "PS4=$(@q "+ $hostworkdir$ ")" \
         "$(
             while [[ $# -gt 0 ]]; do
-                if declare -F "$1" &>/dev/null; then declare -f -- "$1"
-                else declare -p -- "$1"
-                # TODO support when fn is neither a variable nor a function (probably a command)
+                if declare -F "$1" &>/dev/null; then
+                    declare -f -- "$1"
+                else
+                    case $1 in (*=*) declare -- "$1"; v=${1%%=*} ;; (*) v=$1 ;; esac
+                    declare -p -- "$v"
+                    # TODO support when fn is neither a variable nor a function (probably a command)
                 fi
                 shift
             done
@@ -185,13 +188,12 @@ git-tether-remote() {
     }
     rbc "$hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
     # replicate staged changes AKA .git/index
-    local patch=.git/tethered-index.patch
-    x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch
+    x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch=.git/tethered-index.patch
     _remocon_apply_patch_index() {
         x git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
         ! [[ -s "$patch" ]] || x git apply --binary --apply --cached "$patch"
     }
-    rbc "$hostpath" _remocon_apply_patch_index patch
+    rbc "$hostpath" _remocon_apply_patch_index patch=.git/tethered-index.patch
     )
 }
 

--- a/remocon
+++ b/remocon
@@ -200,7 +200,7 @@ remocon.dup() {
             rbc "$dst_hostpath" _remocon_git_init
             x git push -f remocon/remote HEAD:"$branch"
         }
-        # TODO transfer git config to destination
+        # TODO transfer local git config to $dst_hostpath
         x git remote remove remocon/remote
     }
     _remocon_git_fetch() {

--- a/remocon
+++ b/remocon
@@ -20,6 +20,9 @@
 ##
 set -euo pipefail
 
+: ${verbose:=false}
+: ${remote_tmux:=true}
+
 error()   { echo >&2 "📡 ‼️ " "$@"; false; }
 warning() { echo >&2 "📡 ⚠️ " "$@"; }
 info()    { echo >&2 "📡" "$@"; }
@@ -50,11 +53,15 @@ cmdseq() {
 }
 # a handy way to show what command is running
 x() {
-    ! ${verbose:=true} || (
+    (
         case ${1:-} in (builtin|command) shift;; esac
         echo "$PS4$(@q "$@")"
     ) >&2
     "$@"
+}
+$verbose || {
+    x() { "$@"; }
+    alias x=''
 }
 
 mkdelegate() {
@@ -200,7 +207,6 @@ remocon.dup() {
 # defaults to not running things remotely
 remote_host=localhost
 remote_workdir=
-: ${remote_tmux:=true}
 
 ################################################################################
 # common prep and sub-commands
@@ -312,13 +318,14 @@ remocon.get() {
     # TODO remocon.dup $remote_hostrepo $local_hostrepo
     # TODO use git in case rsync is not available?
     x rsync \
-        --verbose \
         --archive \
         --hard-links \
         --omit-dir-times \
         --checksum \
         --copy-unsafe-links \
         --exclude=.git \
+        --partial \
+        $(! $verbose || echo '--progress --verbose') \
         --relative --rsync-path="$(printf 'cd; mkdir -p %q && cd %q &>/dev/null && rsync' "$remote_workdir" "$remote_workdir")" \
         "$remote_host":"$(@q "$@")" .
 } </dev/null >&2

--- a/remocon
+++ b/remocon
@@ -35,7 +35,13 @@ in_full_tty() { [[ -t 0 && -t 1 && -t 2 ]]; }
     echo "${e:2}"
 }
 # a handy way to compose a shell script that consists of multiple commands in one shot
-cmdseq() { printf '%s; ' "$@"; }
+cmdseq() {
+    local cmd
+    for cmd; do
+        [[ -n $cmd ]] || continue
+        printf '%s; ' "$cmd"
+    done
+}
 # a handy way to show what command is running
 x() {
     (
@@ -59,6 +65,29 @@ mkdelegate() {
     chmod +x "$file"
 }
 
+# run on given remote host:workdir given bash function, sending variable and function declarations
+rbashfn() {
+    local hostworkdir=$1; shift
+    local fn=$1; shift
+    case $hostworkdir in
+        (*:*) host=${hostworkdir%%:*} workdir=${hostworkdir#*:};;
+        (*) error "$hostworkdir: HOST[:PATH] required";;
+    esac
+    remote_host="$host" \
+    run-remotely \
+        ": FIXME remove this bogus first arg" \
+        "set -eu" \
+        "mkdir -p $(@q "$dir")" \
+        "cd $(@q "$workdir")" \
+        "PS4=$(@q "+ $hostworkdir$ ")" \
+        "set -x" \
+        "$(declare -p -f -- "$fn")" \
+        "$([[ $# -eq 0 ]] || declare -f -- "$@")" \
+        "$([[ $# -eq 0 ]] || declare -p -- "$@" # TODO exclude declare -F to suppress errors
+        )" \
+        "$fn"
+}
+
 # a handy way to patch remote
 # See: https://github.com/netj/bpm/blob/master/plugin/git-helper
 git-tether-remote() {
@@ -78,14 +107,14 @@ git-tether-remote() {
     git remote add remocon/remote "$host:$dir" 2>/dev/null ||
         git remote set-url remocon/remote "$host:$dir"
     git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
-        bash_remotely "# set -x
-            mkdir -p $(@q "$dir")
-            cd $(@q "$dir")
+        _remocon_git_init() {
+            # set -x
             [[ -e .git ]] || git init
             # lift some git config to allow push
             git config receive.denyCurrentBranch ignore
-        "
-        git push -f remocon/remote HEAD:"$branch"
+        }
+        rbashfn "$hostpath" _remocon_git_init x @q
+        x git push -f remocon/remote HEAD:"$branch"
     }
     # TODO transfer git config to destination
     git remote remove remocon/remote

--- a/remocon
+++ b/remocon
@@ -202,8 +202,12 @@ remocon.dup() {
         # TODO transfer git config to destination
         x git remote remove remocon/remote
     }
-    # TODO pull if dst is localhost
-    rbc "$src_hostpath" _remocon_git_push host dir dst_hostpath branch _remocon_git_init
+    if [[ ! $src_hostpath = localhost:* && $dst_hostpath = localhost:* ]]; then
+        error "pulling git from remote host to local not supported yet"
+        # TODO pull if dst is localhost
+    else
+        rbc "$src_hostpath" _remocon_git_push host dir dst_hostpath branch _remocon_git_init
+    fi
     ########################################
     _actually_rm_files_deleted_from_git_index_that_come_from() {
         local commit=$1; shift
@@ -382,9 +386,11 @@ remocon.run() {
 
 # get remote changes back to local
 remocon.get() {
-    [[ $# -gt 0 ]] || set -- .
+    if [[ $# -eq 0 ]]; then
+        error "pulling git from remote host to local not supported yet; specify relative path args to rsync"
+        remocon.dup localhost:"$(git rev-parse --show-toplevel)" "$remote_host:$remote_repo"
+    else
     info "⏬ [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
-    # TODO remocon.dup $remote_hostrepo $local_hostrepo
     # TODO use git in case rsync is not available?
     x rsync \
         --archive \
@@ -397,22 +403,24 @@ remocon.get() {
         $(! $verbose || echo '--progress --verbose') \
         --relative --rsync-path="$(printf 'cd; mkdir -p %q && cd %q &>/dev/null && rsync' "$remote_workdir" "$remote_workdir")" \
         "$remote_host":"$(@q "$@")" .
+    fi
 } </dev/null >&2
 
 # programming round-trip mode (put-run-get)
 remocon.prg() {
     # find which paths to get from given args
     # (NOTE path list can be terminated by a double-dash `--` to delinate the command to run)
+    local dashdash=false
     local pathsToPull=
     pathsToPull=()
     while [[ $# -gt 0 ]]; do
         local arg=$1; shift
         case $arg in
-            --) break ;;
+            --) dashdash=true; break ;;
             *) pathsToPull+=("$arg")
         esac
     done
-    # TODO require a non-empty pathsToPull or default to .
+    $dashdash || error 'zero or more paths to get after running must be specified before a double-dash `--`'
 
     # run command if any were given (after a dash-dash)
     local exitStatus=0

--- a/remocon
+++ b/remocon
@@ -81,23 +81,6 @@ mkdelegate() {
 }
 
 # remote bash call -- run on given remote host:workdir given bash function, sending variable and function declarations
-ssh_opts=(
-)
-bash_opts=(
-    bash
-)
-declarationsFor() {
-    while [[ $# -gt 0 ]]; do
-        if declare -F "$1" &>/dev/null; then
-            declare -f -- "$1"
-        else
-            case $1 in (*=*) declare -- "$1"; v=${1%%=*} ;; (*) v=$1 ;; esac
-            declare -p -- "$v"
-            # TODO support when fn is neither a variable nor a function (probably a command)
-        fi
-        shift
-    done
-}
 rbc() {
     local hostworkdir=$1; shift
     local fn=$1; shift
@@ -129,6 +112,23 @@ rbc() {
             ssh "$host" "${ssh_opts[@]:---}" "$(@q "$@")"
             ;;
     esac
+}
+ssh_opts=(
+)
+bash_opts=(
+    bash
+)
+declarationsFor() {
+    while [[ $# -gt 0 ]]; do
+        if declare -F "$1" &>/dev/null; then
+            declare -f -- "$1"
+        else
+            case $1 in (*=*) declare -- "$1"; v=${1%%=*} ;; (*) v=$1 ;; esac
+            declare -p -- "$v"
+            # TODO support when fn is neither a variable nor a function (probably a command)
+        fi
+        shift
+    done
 }
 
 # how to duplicate one git worktree to another

--- a/remocon
+++ b/remocon
@@ -94,20 +94,6 @@ $verbose || {
 x_prefix_for_remote() { echo "+ $1$ "; }
 silently() { "$@"; } 2>/dev/null
 
-mkdelegate() {
-    : echo 'generates an executable file for delegating with extra options'
-    : echo
-    : echo 'mkdelegate FILE ABS_PATH_TO_COMMAND [OPTION...]'
-    local file=$1; shift
-    mkdir -p "$(dirname "$file")"
-    local script=$(
-        echo '#!/bin/sh'
-        echo "$(@q exec "$@")" '"$@"'
-    )
-    diff -q <(echo "$script") "$file" &>/dev/null || echo "$script" >"$file"
-    chmod +x "$file"
-}
-
 # remote bash call -- run on given remote host:workdir given bash function, sending variable and function declarations
 rbc() {
     local _rbc_hostworkdir=$1; shift
@@ -167,6 +153,20 @@ declarationsFor() {
         fi
         shift
     done
+}
+
+mkdelegate() {
+    : echo 'generates an executable file for delegating with extra options'
+    : echo
+    : echo 'mkdelegate FILE ABS_PATH_TO_COMMAND [OPTION...]'
+    local file=$1; shift
+    mkdir -p "$(dirname "$file")"
+    local script=$(
+        echo '#!/bin/sh'
+        echo "$(@q exec "$@")" '"$@"'
+    )
+    diff -q <(echo "$script") "$file" &>/dev/null || echo "$script" >"$file"
+    chmod +x "$file"
 }
 
 # how to duplicate one git worktree to another

--- a/remocon
+++ b/remocon
@@ -74,15 +74,15 @@ rbc() {
         (*) error "$hostworkdir: HOST[:PATH] required";;
     esac
     # prepare command sequence from given function, variable names
+    set -- x @q rbc "$@"  # adding default
     set -- \
         "set -eu" \
         "mkdir -p $(@q "$dir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "+ $hostworkdir$ ")" \
-        "set -x" \
-        "$([[ $# -eq 0 ]] || declare -f -- "$fn" "$@"  # TODO support when fn is a command; not a function
-        )" \
         "$([[ $# -eq 0 ]] || declare -p -- "$@" # TODO exclude declare -F to suppress errors
+        )" \
+        "$([[ $# -eq 0 ]] || declare -f -- "$@" "$fn"  # TODO support when fn is a command; not a function
         )" \
         "$fn"
     # determine how to run the function
@@ -125,11 +125,11 @@ git-tether-remote() {
     x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
         _remocon_git_init() {
             # set -x
-            [[ -e .git ]] || git init
+            [[ -e .git ]] || x git init
             # lift some git config to allow push
-            git config receive.denyCurrentBranch ignore
+            x git config receive.denyCurrentBranch ignore
         }
-        rbc "$hostpath" _remocon_git_init x @q
+        rbc "$hostpath" _remocon_git_init
         x git push -f remocon/remote HEAD:"$branch"
     }
     # TODO transfer git config to destination
@@ -145,19 +145,19 @@ git-tether-remote() {
         # set -x
         # reverse any previous patch for tethering
         if [[ -s "$patch" ]]; then
-            git apply --binary -R <"$patch" || git stash
+            x git apply --binary -R "$patch" || x git stash
             mv -f "$patch"{,~}
         fi
         if git rev-parse HEAD &>/dev/null; then
             # preserve any outstanding/untethered changes
-            git diff --quiet --exit-code HEAD -- || git stash
+            git diff --quiet --exit-code HEAD -- || x git stash
             # make sure we're on the tethered branch and commit
-            [[ $(git symbolic-ref --short HEAD) = $branch ]] || git checkout -f $branch --
+            [[ $(git symbolic-ref --short HEAD) = $branch ]] || x git checkout -f $branch --
         else
             # no branch was checked out before
-            git checkout -f $branch --
+            x git checkout -f $branch --
         fi
-        git reset --hard $commit
+        x git reset --hard $commit
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD@{1}  # (necessary as git-reset does not always handle delete files cleanly)
     }
     rbc "$hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
@@ -166,9 +166,9 @@ git-tether-remote() {
     x git diff --full-index --binary HEAD | rbc "$hostpath" _remocon_write_patch patch
     _remocon_apply_patch() {
         # with the same outstanding changes on top of the current commit
-        ! [[ -s "$patch" ]] || git apply --binary --apply --stat --cached <"$patch"
+        ! [[ -s "$patch" ]] || x git apply --binary --apply --stat --cached "$patch"
         # (relying on git-checkout from current git index takes care of a lot, such as permissions, symlinks)
-        git checkout --quiet .
+        x git checkout --quiet .
         # (however, git-checkout does not handle deleted files nicely, so ensuring any files in HEAD that fell into --others are removed)
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD
     }
@@ -177,8 +177,8 @@ git-tether-remote() {
     x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch
     local patch=.git/tethered-index.patch
     _remocon_apply_patch_index() {
-        git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
-        ! [[ -s "$patch" ]] || git apply --binary --apply --cached <"$patch"
+        x git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
+        ! [[ -s "$patch" ]] || x git apply --binary --apply --cached "$patch"
     }
     rbc "$hostpath" _remocon_apply_patch_index patch
     )

--- a/remocon
+++ b/remocon
@@ -377,10 +377,8 @@ remocon.rec() {
     bash_opts+=(-l)
 
     _remocon_start_tmux_window() {
-        if [[ $(tmux list-sessions 2>/dev/null | wc -l) -eq 0 ]]
-        then x tmux new-session -d
-        else x tmux new-window
-        fi
+        [[ $(tmux list-sessions 2>/dev/null | wc -l) -gt 0 ]] || x tmux new-session -d
+        x tmux new-window
     }
     eval "_remocon_rec_cmd() { $(cmdseq _remocon_start_tmux_window "${@/#/x }"); }"
     rbc "$remote_host:$remote_workdir" _remocon_rec_cmd _remocon_start_tmux_window

--- a/remocon
+++ b/remocon
@@ -65,27 +65,47 @@ mkdelegate() {
     chmod +x "$file"
 }
 
-# run on given remote host:workdir given bash function, sending variable and function declarations
-rbashfn() {
+# remote bash call -- run on given remote host:workdir given bash function, sending variable and function declarations
+rbc() {
     local hostworkdir=$1; shift
     local fn=$1; shift
     case $hostworkdir in
         (*:*) host=${hostworkdir%%:*} workdir=${hostworkdir#*:};;
         (*) error "$hostworkdir: HOST[:PATH] required";;
     esac
-    remote_host="$host" \
-    run-remotely \
-        ": FIXME remove this bogus first arg" \
+    # prepare command sequence from given function, variable names
+    set -- \
         "set -eu" \
         "mkdir -p $(@q "$dir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "+ $hostworkdir$ ")" \
         "set -x" \
-        "$(declare -p -f -- "$fn")" \
-        "$([[ $# -eq 0 ]] || declare -f -- "$@")" \
+        "$([[ $# -eq 0 ]] || declare -f -- "$fn" "$@"  # TODO support when fn is a command; not a function
+        )" \
         "$([[ $# -eq 0 ]] || declare -p -- "$@" # TODO exclude declare -F to suppress errors
         )" \
         "$fn"
+    # determine how to run the function
+    local ssh_opts bash_opts
+    ssh_opts=(
+    )
+    bash_opts=(
+        bash
+    )
+    if in_full_tty; then
+        # when stdin/out/err is a fully functional terminal
+        ssh_opts+=(-t)   # ask ssh for tty
+        bash_opts+=(-i)  # ask bash for an interactive shell
+    fi
+    set -- "${bash_opts[@]}" -c "$(cmdseq "$@")"
+    case $host in
+        localhost)  # special case: run it directly if on same host
+            "$@"
+            ;;
+        *)  # send it over to remote via ssh by default
+            ssh "$host" "${ssh_opts[@]:---}" "$(@q "$@")"
+            ;;
+    esac
 }
 
 # a handy way to patch remote
@@ -113,7 +133,7 @@ git-tether-remote() {
             # lift some git config to allow push
             git config receive.denyCurrentBranch ignore
         }
-        rbashfn "$hostpath" _remocon_git_init x @q
+        rbc "$hostpath" _remocon_git_init x @q
         x git push -f remocon/remote HEAD:"$branch"
     }
     # TODO transfer git config to destination
@@ -177,6 +197,7 @@ bash_opts=(
     bash
 )
 # shorthand to run given sequence of commands remotely
+# TODO deprecate and replace with rbc instead
 run-remotely() {
     local script=$1; shift
     if in_full_tty; then

--- a/remocon
+++ b/remocon
@@ -229,9 +229,9 @@ remocon.dup() {
         x git reset --hard $commit
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD@{1}  # (necessary as git-reset does not always handle delete files cleanly)
     }
-    _remocon_write_patch() { tee "$patch" >/dev/null; }  # TODO fold this into apply_patch
-    _remocon_make_patch() { x git diff --full-index --binary HEAD; }
+    _remocon_make_patch() { x git diff --full-index --binary $for; }
     _remocon_apply_patch() {
+        tee "$patch" >/dev/null
         # with the same outstanding changes on top of the current commit
         ! [[ -s "$patch" ]] || x git apply --binary --apply --stat --cached "$patch"
         # (relying on git-checkout from current git index takes care of a lot, such as permissions, symlinks)
@@ -239,8 +239,8 @@ remocon.dup() {
         # (however, git-checkout does not handle deleted files nicely, so ensuring any files in HEAD that fell into --others are removed)
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD
     }
-    _remocon_make_patch_index() { x git diff --full-index --binary --cached; }
     _remocon_apply_patch_index() {
+        tee "$patch" >/dev/null
         x git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
         ! [[ -s "$patch" ]] || x git apply --binary --apply --cached "$patch"
     }
@@ -248,11 +248,11 @@ remocon.dup() {
     local patch=.git/tethered.patch
     rbc "$dst_hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
     # send staged and unstaged changes
-    rbc "$src_hostpath" _remocon_make_patch | rbc "$dst_hostpath" _remocon_write_patch patch
+    rbc "$src_hostpath" _remocon_make_patch for=HEAD |
     rbc "$dst_hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
     # replicate staged changes AKA .git/index
     local patch=.git/tethered-index.patch
-    rbc "$src_hostpath" _remocon_make_patch_index | rbc "$dst_hostpath" _remocon_write_patch patch
+    rbc "$src_hostpath" _remocon_make_patch for=--cached |
     rbc "$dst_hostpath" _remocon_apply_patch_index patch
 }
 

--- a/remocon
+++ b/remocon
@@ -127,7 +127,7 @@ rbc() {
     local _rbc_decls
     _rbc_decls=$(declarationsFor "$@")
     set -- \
-        "set -eu" \
+        "set -euo pipefail" \
         "cd" \
         "mkdir -p $(@q "$_rbc_workdir")" \
         "cd $(@q "$_rbc_workdir")" \
@@ -172,7 +172,6 @@ declarationsFor() {
 # how to duplicate one git worktree to another
 # Origin: https://github.com/netj/bpm/blob/master/plugin/git-helper
 remocon.dup() {
-    set -euo pipefail
     local dst_hostpath=$1; shift
     local src_hostpath="${1:-localhost:${PWD#$HOME/}}"; [[ $# -eq 0 ]] || shift
     case $dst_hostpath in

--- a/remocon
+++ b/remocon
@@ -125,6 +125,7 @@ rbc() {
     decls=$(declarationsFor "$@")
     set -- \
         "set -eu" \
+        "cd" \
         "mkdir -p $(@q "$workdir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "$(x_prefix_for_remote "$hostworkdir")")" \
@@ -169,36 +170,38 @@ declarationsFor() {
 remocon.dup() {
     (
     set -euo pipefail
-    dst_hostpath=$1; shift
-    # TODO src_hostpath and dst_hostpath
+    local src_hostpath=localhost:"${PWD#$HOME/}"  # TODO parameterize
+    local dst_hostpath=$1; shift
     case $dst_hostpath in
         (*:*) host=${dst_hostpath%%:*} dir=${dst_hostpath#*:};;
         (*) error "$dst_hostpath: HOST[:PATH] required";;
     esac
+    ########################################
+    # ensure destination git clone has the source's commit
+    _remocon_git_init() {
+        # set -x
+        [[ -e .git ]] || x git init
+        # lift some git config to allow push
+        x git config receive.denyCurrentBranch ignore
+    }
+    # TODO wrap below in a rbc "$src_hostpath"
     commit=$(git rev-parse HEAD)
     branch=$(git symbolic-ref --short HEAD)
     x git remote add remocon/remote "$host:$dir" 2>/dev/null ||
         x git remote set-url remocon/remote "$host:$dir"
     # TODO pull if dst is localhost
     x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
-        _remocon_git_init() {
-            # set -x
-            [[ -e .git ]] || x git init
-            # lift some git config to allow push
-            x git config receive.denyCurrentBranch ignore
-        }
         rbc "$dst_hostpath" _remocon_git_init
         x git push -f remocon/remote HEAD:"$branch"
     }
     # TODO transfer git config to destination
     git remote remove remocon/remote
-    # bring destination to the current commit
+    ########################################
     _actually_rm_files_deleted_from_git_index_that_come_from() {
         local commit=$1; shift
         eval "set -- $(comm -12 <(git ls-tree -r --name-only "$commit" | sort) <(git ls-files --others --exclude-standard | sort) | @q)"
         [[ $# -eq 0 ]] || x rm -f "$@"
     }
-    local patch=.git/tethered.patch
     _remocon_reset_to_HEAD() {
         # reverse any previous patch for tethering
         if [[ -s "$patch" ]]; then
@@ -217,10 +220,8 @@ remocon.dup() {
         x git reset --hard $commit
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD@{1}  # (necessary as git-reset does not always handle delete files cleanly)
     }
-    rbc "$dst_hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
-    # send staged and unstaged changes
-    _remocon_write_patch() { tee "$patch" >/dev/null; }
-    x git diff --full-index --binary HEAD | rbc "$dst_hostpath" _remocon_write_patch patch
+    _remocon_write_patch() { tee "$patch" >/dev/null; }  # TODO fold this into apply_patch
+    _remocon_make_patch() { x git diff --full-index --binary HEAD; }
     _remocon_apply_patch() {
         # with the same outstanding changes on top of the current commit
         ! [[ -s "$patch" ]] || x git apply --binary --apply --stat --cached "$patch"
@@ -229,14 +230,21 @@ remocon.dup() {
         # (however, git-checkout does not handle deleted files nicely, so ensuring any files in HEAD that fell into --others are removed)
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD
     }
-    rbc "$dst_hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
-    # replicate staged changes AKA .git/index
-    x git diff --full-index --binary --cached | rbc "$dst_hostpath" _remocon_write_patch patch=.git/tethered-index.patch
+    _remocon_make_patch_index() { x git diff --full-index --binary --cached; }
     _remocon_apply_patch_index() {
         x git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
         ! [[ -s "$patch" ]] || x git apply --binary --apply --cached "$patch"
     }
-    rbc "$dst_hostpath" _remocon_apply_patch_index patch=.git/tethered-index.patch
+    # bring destination to the current commit
+    local patch=.git/tethered.patch
+    rbc "$dst_hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
+    # send staged and unstaged changes
+    rbc "$src_hostpath" _remocon_make_patch | rbc "$dst_hostpath" _remocon_write_patch patch
+    rbc "$dst_hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
+    # replicate staged changes AKA .git/index
+    local patch=.git/tethered-index.patch
+    rbc "$src_hostpath" _remocon_make_patch_index | rbc "$dst_hostpath" _remocon_write_patch patch
+    rbc "$dst_hostpath" _remocon_apply_patch_index patch
     )
 }
 

--- a/remocon
+++ b/remocon
@@ -30,9 +30,13 @@ in_full_tty() { [[ -t 0 && -t 1 && -t 2 ]]; }
 
 # a nimble/simple way to use bash -x itself to get single-quoted escapes instead of backslashes given by printf %q
 @q() {
-    local e
-    e=$(PS4= bash --norc -xc ': "$@"' -- "$@" 2>&1)
-    echo "${e:2}"
+    if [[ $# -eq 0 ]]; then  # quote each line in stdin
+        sed "s/'/'\\\\''/g; s/^/'/; s/\$/'/"
+    else
+        local e
+        e=$(PS4= bash --norc -xc ': "$@"' -- "$@" 2>&1)
+        echo "${e:2}"
+    fi
 }
 # a handy way to compose a shell script that consists of multiple commands in one shot
 cmdseq() {
@@ -142,15 +146,15 @@ git-tether-remote() {
     # bring destination to the current commit
     _actually_rm_files_deleted_from_git_index_that_come_from() {
         local commit=$1; shift
-        comm -12 <(git ls-tree -r --name-only "$commit" | sort) <(git ls-files --others --exclude-standard | sort) |
-        tr '\n' '\0' | xargs -0 rm -f
+        eval "set -- $(comm -12 <(git ls-tree -r --name-only "$commit" | sort) <(git ls-files --others --exclude-standard | sort) | @q)"
+        [[ $# -eq 0 ]] || x rm -f "$@"
     }
     local patch=.git/tethered.patch
     _remocon_reset_to_HEAD() {
         # reverse any previous patch for tethering
         if [[ -s "$patch" ]]; then
             x git apply --binary -R "$patch" || x git stash
-            mv -f "$patch"{,~}
+            x mv -f "$patch"{,~}
         fi
         if git rev-parse HEAD &>/dev/null; then
             # preserve any outstanding/untethered changes

--- a/remocon
+++ b/remocon
@@ -163,11 +163,13 @@ run-remotely() {
 ################################################################################
 # common prep and sub-commands
 
+# TODO turn below into a function and call it from bottom
 {
     # make sure we're in a git work tree
     $(git rev-parse --is-inside-work-tree) ||
         error "$PWD: Not inside a git work tree"
 
+    # TODO migrate remocon.conf to git config
     # find closest .remocon.conf
     conf=$(
         until [[ $PWD = / || -e .remocon.conf ]]; do cd ..; done
@@ -241,6 +243,7 @@ remocon.set() {
 # tether remote git repo to local one
 remocon.put() {
     [[ $# -eq 0 ]] || error "Cannot put partial changes under given paths: $(@q "$@")"
+    # TODO accept multiple remotes as args
     info "[$remote_host:$remote_repo/] 🛰 putting a replica of local git work tree on remote"
     git-tether-remote "$remote_host:$remote_repo"
 } </dev/null >&2

--- a/remocon
+++ b/remocon
@@ -22,6 +22,8 @@ set -euo pipefail
 
 : ${verbose:=false}
 : ${remote_tmux:=true}
+: ${remote:=localhost} # defaults to not running things remotely
+
 
 error()   { echo >&2 "📡 ‼️ " "$@"; false; }
 warning() { echo >&2 "📡 ⚠️ " "$@"; }
@@ -84,6 +86,18 @@ ssh_opts=(
 bash_opts=(
     bash
 )
+declarationsFor() {
+    while [[ $# -gt 0 ]]; do
+        if declare -F "$1" &>/dev/null; then
+            declare -f -- "$1"
+        else
+            case $1 in (*=*) declare -- "$1"; v=${1%%=*} ;; (*) v=$1 ;; esac
+            declare -p -- "$v"
+            # TODO support when fn is neither a variable nor a function (probably a command)
+        fi
+        shift
+    done
+}
 rbc() {
     local hostworkdir=$1; shift
     local fn=$1; shift
@@ -98,18 +112,7 @@ rbc() {
         "mkdir -p $(@q "$workdir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "+ $hostworkdir$ ")" \
-        "$(
-            while [[ $# -gt 0 ]]; do
-                if declare -F "$1" &>/dev/null; then
-                    declare -f -- "$1"
-                else
-                    case $1 in (*=*) declare -- "$1"; v=${1%%=*} ;; (*) v=$1 ;; esac
-                    declare -p -- "$v"
-                    # TODO support when fn is neither a variable nor a function (probably a command)
-                fi
-                shift
-            done
-        )" \
+        "$(declarationsFor "$@")" \
         "$fn"
     # determine how to run the function
     if in_full_tty; then
@@ -204,28 +207,32 @@ remocon.dup() {
     )
 }
 
-# defaults to not running things remotely
-remote_host=localhost
-remote_workdir=
-
 ################################################################################
-# common prep and sub-commands
+# common prep
 
-# TODO turn below into a function and call it from bottom
-{
+remocon._init() {
+    remocon._parse_config
+    remocon._setup_ssh_booster
+    # break the ssh connection when interrupted, e.g., ControlPath can get stale
+    trap 'x ssh "$remote_host" -O stop' INT
+} </dev/null >/dev/null
+
+remocon._parse_config() {
+    {
     # make sure we're in a git work tree
     $(git rev-parse --is-inside-work-tree) ||
         error "$PWD: Not inside a git work tree"
 
     # TODO migrate remocon.conf to git config
     # find closest .remocon.conf
+    local conf
     conf=$(
         until [[ $PWD = / || -e .remocon.conf ]]; do cd ..; done
         ! [[ -e .remocon.conf ]] || echo "$PWD"/.remocon.conf
     )
 
     # load from .remocon.conf but let what's in environ override
-    ! declare -p remote &>/dev/null || remote_override=$remote
+    ! declare -p remote &>/dev/null || local remote_override=$remote
     ! [[ -e "$conf" ]] || source "$conf"
     ! declare -p remote_override &>/dev/null || remote=$remote_override
     # TODO let all remote_* vars to be overriddable by env vars, e.g., remote_tmux
@@ -234,7 +241,8 @@ remote_workdir=
     [[ -n ${remote:=} || ${1:-} = set ]] || error "No remote configured. Please run: remocon set"
 
     # parse remote
-    remote_host=${remote%%:*}
+    local remote_repo_root
+    remote_host="${remote%%:*}"
     remote_repo_root=${remote#$remote_host}
     remote_repo_root=${remote_repo_root#:}
 
@@ -242,13 +250,23 @@ remote_workdir=
     remote_repo=${remote_repo_root:+$remote_repo_root/}$(basename "$(git rev-parse --show-toplevel)")
 
     # determine remote workdir based on where in the git repo we're in
-    local_path_within_git=$(git rev-parse --show-prefix)
+    local local_path_to_git_top local_path_within_git
     local_path_to_git_top=$(git rev-parse --show-toplevel)
-    local_path_to_git_top_abbrev=${local_path_to_git_top#$HOME/}
-    PS4="+ localhost:$local_path_to_git_top_abbrev\$ "  # to let `x` show more informative lines to stderr
+    PS4="+ localhost:${local_path_to_git_top#$HOME/}\$ "  # to let `x` show more informative lines to stderr
+    local_path_within_git=$(git rev-parse --show-prefix)
     remote_workdir="${remote_repo}/${local_path_within_git#/}"
+    } >&2
 
+    local v
+    for v in remote{,_{host,repo,workdir}}
+    do @q "$v=${!v}"
+    done
+} </dev/null
+
+remocon._setup_ssh_booster() {
+    {
     # override ssh options/config
+    local sshBoosterOpts
     sshBoosterOpts=(
         # share an ssh connection across invocation
         -o ControlMaster=auto
@@ -257,15 +275,19 @@ remote_workdir=
         # forward agent
         -A
     )
-    sshBoosterRoot=~/.cache/remocon/ssh
+    local sshBoosterRoot=~/.cache/remocon/ssh
+    local cmd
     for cmd in scp ssh; do
         mkdelegate "$sshBoosterRoot"/bin/"$cmd" "$(type -p "$cmd")" "${sshBoosterOpts[@]}"
     done
-    PATH="$sshBoosterRoot"/bin:"$PATH"
-} </dev/null >&2
+    } >&2
 
-# break the ssh connection when interrupted, e.g., ControlPath can get stale
-trap 'x ssh "$remote_host" -O stop' INT
+    echo 'export PATH='"$(@q "$sshBoosterRoot"/bin)"':"$PATH"'
+} </dev/null
+
+
+################################################################################
+# sub-commands
 
 # prints configured remote, inferred remote_repo root, remote_workdir
 remocon.remote() { echo "$remote"; }
@@ -393,25 +415,30 @@ remocon.rec() {
     rbc "$remote_host:$remote_workdir" _remocon_rec_cmd _remocon_start_tmux_window
 }
 
+
 ################################################################################
-# dispatch sub-commands
-
-if ! [[ $# -gt 0 ]]; then
-    if in_full_tty; then
-        # in a tty, defaults to replicating and opening a new TMUX window or an interactive/login shell on remote
-        if $remote_tmux; then
-            set -- rec
+# dispatching sub-commands
+remocon() {
+    if ! [[ $# -gt 0 ]]; then
+        if in_full_tty; then
+            # in a tty, defaults to replicating and opening a new TMUX window or an interactive/login shell on remote
+            if $remote_tmux; then
+                set -- rec
+            else
+                set -- run
+            fi
         else
-            set -- run
+            # otherwise, defaults to just replicating local git work tree to remote
+            set -- put
         fi
-    else
-        # otherwise, defaults to just replicating local git work tree to remote
-        set -- put
     fi
-fi
 
-cmd=$1; shift
-handler="remocon.$cmd"
-type "$handler" &>/dev/null ||
-    error "$cmd: No such command.  Command must be one of: set, put, run, get, prg, or rec"
-"$handler" "$@"
+    cmd=$1; shift
+    handler="remocon.$cmd"
+    type "$handler" &>/dev/null ||
+        error "$cmd: No such command.  Command must be one of: set, put, run, get, prg, or rec"
+    case $cmd in _*) ;; *) remocon._init ;; esac  # common prep for normal commands
+    "$handler" "$@"
+}
+
+remocon "$@"

--- a/remocon
+++ b/remocon
@@ -277,7 +277,7 @@ remocon.set() {
         local remote=$1; shift
     fi
     [[ -n $remote ]] || error "No remote specified"
-    info "[$remote] ⚙️ setting ~/.remocon.conf"
+    info "⚙️ [$remote] setting ~/.remocon.conf"
     printf >>~/.remocon.conf 'remote=%q\n' "$remote"
 }
 
@@ -285,8 +285,7 @@ remocon.set() {
 remocon.put() {
     [[ $# -eq 0 ]] || error "Cannot put partial changes under given paths: $(@q "$@")"
     # TODO accept multiple remotes as args
-    # TODO move emojis to the beginning
-    info "[$remote_host:$remote_repo/] 🛰 putting a replica of local git work tree on remote"
+    info "🛰 [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
     git-tether-remote "$remote_host:$remote_repo"
     # TODO src_hostpath and dst_hostpath
     # TODO rename git-tether-remote to remocon.dup
@@ -297,7 +296,7 @@ remocon.run() {
     remocon.put
 
     [[ $# -gt 0 ]] || set -- bash -il
-    info "[$remote_host:$remote_workdir] ⚡️ running command: $(@q "$@")"
+    info "⚡️ [$remote_host:$remote_workdir] running command: $(@q "$@")"
 
     eval "_remocon_run_cmd() { x $(@q "$@"); }"
     rbc "$remote_host:$remote_workdir" _remocon_run_cmd
@@ -306,7 +305,7 @@ remocon.run() {
 # get remote changes back to local
 remocon.get() {
     [[ $# -gt 0 ]] || set -- .
-    info "[$remote_host:$remote_workdir] 💎 getting remote files under $# paths: $(@q "$@")"
+    info "💎 [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
     # TODO use git in case rsync is not available?
     x rsync \
         --verbose \
@@ -350,12 +349,12 @@ remocon.rec() {
     remocon.put
 
     if [[ $# -gt 0 ]]; then
-        info "[$remote_host:$remote_workdir] ✨ recording a new TMUX window with: $(@q "$@")"
+        info "✨ [$remote_host:$remote_workdir] recording a new TMUX window with: $(@q "$@")"
         set -- "tmux send-keys C-L $(@q "$(@q "$@")") Enter"
         ! in_full_tty || warning "[$remote_host:$remote_workdir] attaching to the new TMUX window (TIP: append \` |:\` to command-line to prevent this)"
     elif in_full_tty; then
         # in a tty, provide a handy way to create a new window in the same TMUX session
-        info "[$remote_host:$remote_workdir] ✨ recording a new TMUX window for an interactive session"
+        info "✨ [$remote_host:$remote_workdir] recording a new TMUX window for an interactive session"
     else
         error 'Missing command. remocon rec can attach to a new TMUX window in a tty, but requires a command otherwise.'
     fi

--- a/remocon
+++ b/remocon
@@ -48,7 +48,7 @@ cmdseq() {
 }
 # a handy way to show what command is running
 x() {
-    (
+    ! ${verbose:=true} || (
         case ${1:-} in (builtin|command) shift;; esac
         echo "$PS4$(@q "$@")"
     ) >&2

--- a/remocon
+++ b/remocon
@@ -181,8 +181,8 @@ git-tether-remote() {
     }
     rbc "$hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
     # replicate staged changes AKA .git/index
-    x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch
     local patch=.git/tethered-index.patch
+    x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch
     _remocon_apply_patch_index() {
         x git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
         ! [[ -s "$patch" ]] || x git apply --binary --apply --cached "$patch"

--- a/remocon
+++ b/remocon
@@ -289,7 +289,7 @@ remocon.set() {
 remocon.put() {
     [[ $# -eq 0 ]] || error "Cannot put partial changes under given paths: $(@q "$@")"
     # TODO accept multiple remotes as args
-    info "🛰 [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
+    info "⏫ [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
     remocon.dup "$remote_host:$remote_repo"
     # TODO remocon.dup $local_hostrepo $remote_hostrepo
 } </dev/null >&2
@@ -299,7 +299,7 @@ remocon.run() {
     remocon.put
 
     [[ $# -gt 0 ]] || set -- bash -il
-    info "⚡️ [$remote_host:$remote_workdir] running command: $(@q "$@")"
+    info "▶️ [$remote_host:$remote_workdir] running command: $(@q "$@")"
 
     eval "_remocon_run_cmd() { x $(@q "$@"); }"
     rbc "$remote_host:$remote_workdir" _remocon_run_cmd
@@ -308,7 +308,7 @@ remocon.run() {
 # get remote changes back to local
 remocon.get() {
     [[ $# -gt 0 ]] || set -- .
-    info "💎 [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
+    info "⏬ [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
     # TODO remocon.dup $remote_hostrepo $local_hostrepo
     # TODO use git in case rsync is not available?
     x rsync \
@@ -353,12 +353,12 @@ remocon.rec() {
     remocon.put
 
     if [[ $# -gt 0 ]]; then
-        info "✨ [$remote_host:$remote_workdir] recording a new TMUX window with: $(@q "$@")"
+        info "⏺ [$remote_host:$remote_workdir] recording a new TMUX window with: $(@q "$@")"
         set -- "tmux send-keys C-L $(@q "$(@q "$@")") Enter"
         ! in_full_tty || warning "[$remote_host:$remote_workdir] attaching to the new TMUX window (TIP: append \` |:\` to command-line to prevent this)"
     elif in_full_tty; then
         # in a tty, provide a handy way to create a new window in the same TMUX session
-        info "✨ [$remote_host:$remote_workdir] recording a new TMUX window for an interactive session"
+        info "⏺ [$remote_host:$remote_workdir] recording a new TMUX window for an interactive session"
     else
         error 'Missing command. remocon rec can attach to a new TMUX window in a tty, but requires a command otherwise.'
     fi

--- a/remocon
+++ b/remocon
@@ -70,6 +70,11 @@ mkdelegate() {
 }
 
 # remote bash call -- run on given remote host:workdir given bash function, sending variable and function declarations
+ssh_opts=(
+)
+bash_opts=(
+    bash
+)
 rbc() {
     local hostworkdir=$1; shift
     local fn=$1; shift
@@ -95,12 +100,6 @@ rbc() {
         )" \
         "$fn"
     # determine how to run the function
-    local ssh_opts bash_opts
-    ssh_opts=(
-    )
-    bash_opts=(
-        bash
-    )
     if in_full_tty; then
         # when stdin/out/err is a fully functional terminal
         ssh_opts+=(-t)   # ask ssh for tty
@@ -196,24 +195,6 @@ git-tether-remote() {
 remote_host=localhost
 remote_workdir=
 : ${remote_tmux:=true}
-ssh_opts=(
-)
-bash_opts=(
-    bash
-)
-# shorthand to run given sequence of commands remotely
-# TODO deprecate and replace with rbc instead
-run-remotely() {
-    local script=$1; shift
-    if in_full_tty; then
-        # when I/O/Err is a fully functional terminal
-        ssh_opts+=(-t)   # ask ssh for tty
-        bash_opts+=(-i)  # ask bash for an interactive shell
-    fi
-    x ssh "$remote_host" \
-        "${ssh_opts[@]:---}" \
-        "$(@q "${bash_opts[@]}" -c "$(cmdseq "$@")")"
-}
 
 ################################################################################
 # common prep and sub-commands
@@ -310,24 +291,8 @@ remocon.run() {
     [[ $# -gt 0 ]] || set -- bash -il
     info "[$remote_host:$remote_workdir] ⚡️ running command: $(@q "$@")"
 
-    case $remote_host in
-        localhost)
-            # just run given command when remote is local
-            warning "[$remote_host] Not running remotely"
-            x mkdir -p "$remote_workdir"
-            x cd "$remote_workdir"
-            x "$@"
-            ;;
-
-        *)
-            run-remotely \
-                'cd' \
-                'set -eu' \
-                "mkdir -p $(@q "$remote_workdir")" \
-                "cd $(@q "$remote_workdir")" \
-                "exec $(@q "$@")" \
-                #
-    esac
+    eval "_remocon_run_cmd() { x $(@q "$@"); }"
+    rbc "$remote_host:$remote_workdir" _remocon_run_cmd
 }
 
 # get remote changes back to local
@@ -397,14 +362,15 @@ remocon.rec() {
     # when interacting with tmux, doing it from a login shell may be slightly more desirable
     bash_opts+=(-l)
 
-    run-remotely \
-        'tmux start-server' \
-        'if [[ $(tmux list-sessions | wc -l) -eq 0 ]]' \
-        "then tmux new-session -d" \
-        "else tmux new-window    " \
-        'fi' \
-        "$@" \
-        #
+    _remocon_start_tmux_window() {
+        tmux start-server
+        if [[ $(tmux list-sessions | wc -l) -eq 0 ]]
+        then tmux new-session -d
+        else tmux new-window
+        fi
+    }
+    eval "_remocon_rec_cmd() { _remocon_start_tmux_window; x $(@q "$@"); }"
+    rbc "$remote_host:$remote_workdir" _remocon_rec_cmd _remocon_start_tmux_window
 }
 
 ################################################################################

--- a/remocon
+++ b/remocon
@@ -92,6 +92,7 @@ $verbose || {
     alias x=''
 }
 x_prefix_for_remote() { echo "+ $1$ "; }
+silently() { "$@"; } 2>/dev/null
 
 mkdelegate() {
     : echo 'generates an executable file for delegating with extra options'
@@ -119,7 +120,7 @@ rbc() {
     # prepare command sequence from given function, variable names
     ! [[ -t 1 ]] || : ${force_color:=true}
     set -- "force_color=${force_color:-}" coloring \
-        error warning info \
+        error warning info silently \
         rbc x x_prefix_for_remote @q declarationsFor in_full_tty cmdseq \
         "$@"
     set -- "$@" "$_rbc_fn"  # adding some core names to include
@@ -189,20 +190,19 @@ remocon.dup() {
     local commit branch
     eval "$(rbc "$src_hostpath" _remocon_read_git_HEAD)"
     _remocon_git_init() {
-        # set -x
         [[ -e .git ]] || x git init
         # lift some git config to allow push
         x git config receive.denyCurrentBranch ignore
     }
     _remocon_git_push() {
-        x git remote add remocon/remote "$host:$dir" 2>/dev/null ||
+        x silently git remote add remocon/remote "$host:$dir" ||
             x git remote set-url remocon/remote "$host:$dir"
-        x git push -q -f remocon/remote HEAD:"$branch" 2>/dev/null || {
+        x silently git push -q -f remocon/remote HEAD:"$branch" || {
             rbc "$dst_hostpath" _remocon_git_init
             x git push -f remocon/remote HEAD:"$branch"
         }
         # TODO transfer git config to destination
-        git remote remove remocon/remote
+        x git remote remove remocon/remote
     }
     # TODO pull if dst is localhost
     rbc "$src_hostpath" _remocon_git_push host dir dst_hostpath branch _remocon_git_init

--- a/remocon
+++ b/remocon
@@ -173,8 +173,8 @@ declarationsFor() {
 # Origin: https://github.com/netj/bpm/blob/master/plugin/git-helper
 remocon.dup() {
     set -euo pipefail
-    local src_hostpath=localhost:"${PWD#$HOME/}"  # TODO parameterize
     local dst_hostpath=$1; shift
+    local src_hostpath="${1:-localhost:${PWD#$HOME/}}"; [[ $# -eq 0 ]] || shift
     case $dst_hostpath in
         (*:*) host=${dst_hostpath%%:*} dir=${dst_hostpath#*:};;
         (*) error "$dst_hostpath: HOST[:PATH] required";;
@@ -368,7 +368,6 @@ remocon.put() {
     # TODO accept multiple remotes as args
     info "⏫ [$remote_host:$remote_repo/] putting a replica of local git work tree on remote"
     remocon.dup "$remote_host:$remote_repo"
-    # TODO remocon.dup $local_hostrepo $remote_hostrepo
 } </dev/null >&2
 
 # put and run given command on remote from the same workdir relative to the git top-level (AKA git prefix)

--- a/remocon
+++ b/remocon
@@ -74,15 +74,20 @@ rbc() {
         (*) error "$hostworkdir: HOST[:PATH] required";;
     esac
     # prepare command sequence from given function, variable names
-    set -- x @q rbc "$@"  # adding default
+    set -- x @q rbc "$@" "$fn"  # adding some core names to include
     set -- \
         "set -eu" \
         "mkdir -p $(@q "$dir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "+ $hostworkdir$ ")" \
-        "$([[ $# -eq 0 ]] || declare -p -- "$@" # TODO exclude declare -F to suppress errors
-        )" \
-        "$([[ $# -eq 0 ]] || declare -f -- "$@" "$fn"  # TODO support when fn is a command; not a function
+        "$(
+            while [[ $# -gt 0 ]]; do
+                if declare -F "$1" &>/dev/null; then declare -f -- "$1"
+                else declare -p -- "$1"
+                # TODO support when fn is neither a variable nor a function (probably a command)
+                fi
+                shift
+            done
         )" \
         "$fn"
     # determine how to run the function
@@ -142,7 +147,6 @@ git-tether-remote() {
     }
     local patch=.git/tethered.patch
     _remocon_reset_to_HEAD() {
-        # set -x
         # reverse any previous patch for tethering
         if [[ -s "$patch" ]]; then
             x git apply --binary -R "$patch" || x git stash

--- a/remocon
+++ b/remocon
@@ -174,10 +174,6 @@ declarationsFor() {
 remocon.dup() {
     local dst_hostpath=$1; shift
     local src_hostpath="${1:-localhost:${PWD#$HOME/}}"; [[ $# -eq 0 ]] || shift
-    case $dst_hostpath in
-        (*:*) host=${dst_hostpath%%:*} dir=${dst_hostpath#*:};;
-        (*) error "$dst_hostpath: HOST[:PATH] required";;
-    esac
     ########################################
     # ensure destination git clone has the source's commit
     _remocon_read_git_HEAD() {
@@ -193,8 +189,13 @@ remocon.dup() {
         x git config receive.denyCurrentBranch ignore
     }
     _remocon_git_push() {
-        x silently git remote add remocon/remote "$host:$dir" ||
-            x git remote set-url remocon/remote "$host:$dir"
+        # running git pull from $src_hostpath
+        case $dst_hostpath in
+            (*:*) local dst_host=${dst_hostpath%%:*} dst_dir=${dst_hostpath#*:};;
+            (*) error "$dst_hostpath: HOST[:PATH] required";;
+        esac
+        x silently git remote add remocon/remote "$dst_host:$dst_dir" ||
+            x git remote set-url remocon/remote "$dst_host:$dst_dir"
         x silently git push -q -f remocon/remote HEAD:"$branch" || {
             rbc "$dst_hostpath" _remocon_git_init
             x git push -f remocon/remote HEAD:"$branch"
@@ -202,11 +203,28 @@ remocon.dup() {
         # TODO transfer git config to destination
         x git remote remove remocon/remote
     }
+    _remocon_git_fetch() {
+        # running git fetch from $dst_hostpath
+        case $src_hostpath in
+            (*:*) local src_host=${src_hostpath%%:*} src_dir=${src_hostpath#*:};;
+            (*) error "$src_hostpath: HOST[:PATH] required";;
+        esac
+        x silently git remote add remocon/remote "$src_host:$src_dir" || {
+            _remocon_git_init
+            x silently git remote add remocon/remote "$src_host:$src_dir" ||
+                x git remote set-url remocon/remote "$src_host:$src_dir"
+        }
+        x silently git fetch -q remocon/remote "$branch" || {
+            x git fetch remocon/remote "$branch"
+        }
+        # TODO transfer git config from $src_hostpath
+        x git remote remove remocon/remote
+    }
     if [[ ! $src_hostpath = localhost:* && $dst_hostpath = localhost:* ]]; then
-        error "pulling git from remote host to local not supported yet"
-        # TODO pull if dst is localhost
+        # need to git fetch if dst is localhost since it's not reachable for git push from src
+        rbc "$dst_hostpath" _remocon_git_fetch src_hostpath branch _remocon_git_init
     else
-        rbc "$src_hostpath" _remocon_git_push host dir dst_hostpath branch _remocon_git_init
+        rbc "$src_hostpath" _remocon_git_push dst_hostpath branch _remocon_git_init
     fi
     ########################################
     _actually_rm_files_deleted_from_git_index_that_come_from() {
@@ -387,8 +405,8 @@ remocon.run() {
 # get remote changes back to local
 remocon.get() {
     if [[ $# -eq 0 ]]; then
-        error "pulling git from remote host to local not supported yet; specify relative path args to rsync"
-        remocon.dup localhost:"$(git rev-parse --show-toplevel)" "$remote_host:$remote_repo"
+    info "⏬ [$remote_host:$remote_workdir] getting remote changes for git tracked files"
+    remocon.dup localhost:"$(git rev-parse --show-toplevel)" "$remote_host:$remote_repo"
     else
     info "⏬ [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
     # TODO use git in case rsync is not available?

--- a/remocon
+++ b/remocon
@@ -169,11 +169,11 @@ declarationsFor() {
 remocon.dup() {
     (
     set -euo pipefail
-    hostpath=$1; shift
+    dst_hostpath=$1; shift
     # TODO src_hostpath and dst_hostpath
-    case $hostpath in
-        (*:*) host=${hostpath%%:*} dir=${hostpath#*:};;
-        (*) error "$hostpath: HOST[:PATH] required";;
+    case $dst_hostpath in
+        (*:*) host=${dst_hostpath%%:*} dir=${dst_hostpath#*:};;
+        (*) error "$dst_hostpath: HOST[:PATH] required";;
     esac
     commit=$(git rev-parse HEAD)
     branch=$(git symbolic-ref --short HEAD)
@@ -187,7 +187,7 @@ remocon.dup() {
             # lift some git config to allow push
             x git config receive.denyCurrentBranch ignore
         }
-        rbc "$hostpath" _remocon_git_init
+        rbc "$dst_hostpath" _remocon_git_init
         x git push -f remocon/remote HEAD:"$branch"
     }
     # TODO transfer git config to destination
@@ -217,10 +217,10 @@ remocon.dup() {
         x git reset --hard $commit
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD@{1}  # (necessary as git-reset does not always handle delete files cleanly)
     }
-    rbc "$hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
+    rbc "$dst_hostpath" _remocon_reset_to_HEAD branch commit patch _actually_rm_files_deleted_from_git_index_that_come_from
     # send staged and unstaged changes
     _remocon_write_patch() { tee "$patch" >/dev/null; }
-    x git diff --full-index --binary HEAD | rbc "$hostpath" _remocon_write_patch patch
+    x git diff --full-index --binary HEAD | rbc "$dst_hostpath" _remocon_write_patch patch
     _remocon_apply_patch() {
         # with the same outstanding changes on top of the current commit
         ! [[ -s "$patch" ]] || x git apply --binary --apply --stat --cached "$patch"
@@ -229,14 +229,14 @@ remocon.dup() {
         # (however, git-checkout does not handle deleted files nicely, so ensuring any files in HEAD that fell into --others are removed)
         _actually_rm_files_deleted_from_git_index_that_come_from HEAD
     }
-    rbc "$hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
+    rbc "$dst_hostpath" _remocon_apply_patch patch _actually_rm_files_deleted_from_git_index_that_come_from
     # replicate staged changes AKA .git/index
-    x git diff --full-index --binary --cached | rbc "$hostpath" _remocon_write_patch patch=.git/tethered-index.patch
+    x git diff --full-index --binary --cached | rbc "$dst_hostpath" _remocon_write_patch patch=.git/tethered-index.patch
     _remocon_apply_patch_index() {
         x git reset --quiet  # (resetting the git index first to apply the patch for locally staged changes)
         ! [[ -s "$patch" ]] || x git apply --binary --apply --cached "$patch"
     }
-    rbc "$hostpath" _remocon_apply_patch_index patch=.git/tethered-index.patch
+    rbc "$dst_hostpath" _remocon_apply_patch_index patch=.git/tethered-index.patch
     )
 }
 

--- a/remocon
+++ b/remocon
@@ -418,22 +418,22 @@ remocon.run() {
 # get remote changes back to local
 remocon.get() {
     if [[ $# -eq 0 ]]; then
-    info "⏬ [$remote_host:$remote_workdir] getting remote changes for git tracked files"
-    remocon.dup localhost:"$(git rev-parse --show-toplevel)" "$remote_host:$remote_repo"
+        info "⏬ [$remote_host:$remote_workdir] getting remote changes for git tracked files"
+        remocon.dup localhost:"$(git rev-parse --show-toplevel)" "$remote_host:$remote_repo"
     else
-    info "⏬ [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
-    # TODO use git in case rsync is not available?
-    x rsync \
-        --archive \
-        --hard-links \
-        --omit-dir-times \
-        --checksum \
-        --copy-unsafe-links \
-        --exclude=.git \
-        --partial \
-        $(! $verbose || echo '--progress --verbose') \
-        --relative --rsync-path="$(printf 'cd; mkdir -p %q && cd %q &>/dev/null && rsync' "$remote_workdir" "$remote_workdir")" \
-        "$remote_host":"$(@q "$@")" .
+        info "⏬ [$remote_host:$remote_workdir] getting remote files under $# paths: $(@q "$@")"
+        # TODO use git in case rsync is not available?
+        x rsync \
+            --archive \
+            --hard-links \
+            --omit-dir-times \
+            --checksum \
+            --copy-unsafe-links \
+            --exclude=.git \
+            --partial \
+            $(! $verbose || echo '--progress --verbose') \
+            --relative --rsync-path="$(printf 'cd; mkdir -p %q && cd %q &>/dev/null && rsync' "$remote_workdir" "$remote_workdir")" \
+            "$remote_host":"$(@q "$@")" .
     fi
 } </dev/null >&2
 

--- a/remocon
+++ b/remocon
@@ -361,7 +361,12 @@ remocon.rec() {
     fi
 
     # cd is better typed than relying on tmux's new-window/session -c option
-    set -- "tmux send-keys $(@q "cd; mkdir -p $(@q "$remote_workdir") && cd $(@q "$remote_workdir")") Enter" "$@"
+    set -- "tmux send-keys $(@q "$(cmdseq \
+            "cd" \
+            "mkdir -p $(@q "$remote_workdir")" \
+            "cd $(@q "$remote_workdir")" \
+            #
+        )") Enter" "$@"
 
     # attach to the new tmux window when in a tty
     ! in_full_tty ||
@@ -371,13 +376,12 @@ remocon.rec() {
     bash_opts+=(-l)
 
     _remocon_start_tmux_window() {
-        tmux start-server
         if [[ $(tmux list-sessions | wc -l) -eq 0 ]]
-        then tmux new-session -d
-        else tmux new-window
+        then x tmux new-session -d
+        else x tmux new-window
         fi
     }
-    eval "_remocon_rec_cmd() { _remocon_start_tmux_window; x $(@q "$@"); }"
+    eval "_remocon_rec_cmd() { $(cmdseq _remocon_start_tmux_window "${@/#/x }") }"
     rbc "$remote_host:$remote_workdir" _remocon_rec_cmd _remocon_start_tmux_window
 }
 

--- a/remocon
+++ b/remocon
@@ -172,7 +172,6 @@ declarationsFor() {
 # how to duplicate one git worktree to another
 # Origin: https://github.com/netj/bpm/blob/master/plugin/git-helper
 remocon.dup() {
-    (
     set -euo pipefail
     local src_hostpath=localhost:"${PWD#$HOME/}"  # TODO parameterize
     local dst_hostpath=$1; shift
@@ -255,7 +254,6 @@ remocon.dup() {
     local patch=.git/tethered-index.patch
     rbc "$src_hostpath" _remocon_make_patch_index | rbc "$dst_hostpath" _remocon_write_patch patch
     rbc "$dst_hostpath" _remocon_apply_patch_index patch
-    )
 }
 
 ################################################################################

--- a/remocon
+++ b/remocon
@@ -24,14 +24,40 @@ set -euo pipefail
 : ${remote_tmux:=true}
 : ${remote:=localhost} # defaults to not running things remotely
 
+################################################################################
 
-error()   { echo >&2 "📡 ‼️ " "$@"; false; }
-warning() { echo >&2 "📡 ⚠️ " "$@"; }
-info()    { echo >&2 "📡" "$@"; }
+coloring() {
+    local c=$1; shift
+    if ${force_color:-false} || [[ -t 1 ]]; then
+        local           red=$'\E[0;31m'
+        local         green=$'\E[0;32m'
+        local          blue=$'\E[0;34m'
+        local          cyan=$'\E[0;36m'
+        local       magenta=$'\E[0;35m'
+        local        yellow=$'\E[0;33m'
+        local         black=$'\E[0;30m'
+        local          gray=$'\E[0;37m'
+        local         white=$'\E[0;38m'
+        local     light_red=$'\E[1;31m'
+        local   light_green=$'\E[1;32m'
+        local    light_blue=$'\E[1;34m'
+        local    light_cyan=$'\E[1;36m'
+        local light_magenta=$'\E[1;35m'
+        local  light_yellow=$'\E[1;33m'
+        local   light_white=$'\E[1;37m'
+        local      no_color=$'\E[0m'
+        local out
+        out=$("$@")
+        echo "${!c}$out$no_color"
+    else
+        "$@"
+    fi
+}
+error()   { coloring light_red    echo >&2 "📡 ‼️ " "$@"; false; }
+warning() { coloring light_yellow echo >&2 "📡 ⚠️ " "$@"; }
+info()    { coloring       cyan   echo >&2 "📡"    "$@"; }
 
 in_full_tty() { [[ -t 0 && -t 1 && -t 2 ]]; }
-
-################################################################################
 
 # a nimble/simple way to use bash -x itself to get single-quoted escapes instead of backslashes given by printf %q
 @q() {
@@ -57,7 +83,7 @@ cmdseq() {
 x() {
     (
         case ${1:-} in (builtin|command) shift;; esac
-        echo "$PS4$(@q "$@")"
+        coloring blue echo "$PS4$(@q "$@")"
     ) >&2
     "$@"
 }
@@ -90,7 +116,11 @@ rbc() {
         (*) error "$hostworkdir: HOST[:PATH] required";;
     esac
     # prepare command sequence from given function, variable names
-    set -- x @q rbc "$@" "$fn"  # adding some core names to include
+    ! [[ -t 1 ]] || : ${force_color:=true}
+    set -- "force_color=${force_color:-}" coloring \
+        error warning info \
+        x @q rbc "$@"
+    set -- "$@" "$fn"  # adding some core names to include
     set -- \
         "set -eu" \
         "mkdir -p $(@q "$workdir")" \

--- a/remocon
+++ b/remocon
@@ -40,10 +40,12 @@ in_full_tty() { [[ -t 0 && -t 1 && -t 2 ]]; }
 }
 # a handy way to compose a shell script that consists of multiple commands in one shot
 cmdseq() {
-    local cmd
+    : ${cmdsep:="; "}
+    local cmd sep=
     for cmd; do
         [[ -n $cmd ]] || continue
-        printf '%s; ' "$cmd"
+        printf "$sep%s" "$cmd"
+        sep=$cmdsep
     done
 }
 # a handy way to show what command is running
@@ -360,7 +362,7 @@ remocon.rec() {
     fi
 
     # cd is better typed than relying on tmux's new-window/session -c option
-    set -- "tmux send-keys $(@q "$(cmdseq \
+    set -- "tmux send-keys $(@q "$(cmdsep=" && " cmdseq \
             "cd" \
             "mkdir -p $(@q "$remote_workdir")" \
             "cd $(@q "$remote_workdir")" \
@@ -380,7 +382,7 @@ remocon.rec() {
         else x tmux new-window
         fi
     }
-    eval "_remocon_rec_cmd() { $(cmdseq _remocon_start_tmux_window "${@/#/x }") }"
+    eval "_remocon_rec_cmd() { $(cmdseq _remocon_start_tmux_window "${@/#/x }"); }"
     rbc "$remote_host:$remote_workdir" _remocon_rec_cmd _remocon_start_tmux_window
 }
 

--- a/remocon
+++ b/remocon
@@ -65,6 +65,7 @@ $verbose || {
     x() { "$@"; }
     alias x=''
 }
+x_prefix_for_remote() { echo "+ $1$ "; }
 
 mkdelegate() {
     : echo 'generates an executable file for delegating with extra options'
@@ -94,7 +95,7 @@ rbc() {
         "set -eu" \
         "mkdir -p $(@q "$workdir")" \
         "cd $(@q "$workdir")" \
-        "PS4=$(@q "+ $hostworkdir$ ")" \
+        "PS4=$(@q "$(x_prefix_for_remote "$hostworkdir")")" \
         "$(declarationsFor "$@")" \
         "$fn"
     # determine how to run the function
@@ -252,7 +253,7 @@ remocon._parse_config() {
     # determine remote workdir based on where in the git repo we're in
     local local_path_to_git_top local_path_within_git
     local_path_to_git_top=$(git rev-parse --show-toplevel)
-    PS4="+ localhost:${local_path_to_git_top#$HOME/}\$ "  # to let `x` show more informative lines to stderr
+    PS4=$(x_prefix_for_remote "localhost:${local_path_to_git_top#$HOME/}")  # to let `x` show more informative lines to stderr
     local_path_within_git=$(git rev-parse --show-prefix)
     remote_workdir="${remote_repo}/${local_path_within_git#/}"
     } >&2

--- a/remocon
+++ b/remocon
@@ -231,6 +231,9 @@ remote_workdir=
 
     # determine remote workdir based on where in the git repo we're in
     local_path_within_git=$(git rev-parse --show-prefix)
+    local_path_to_git_top=$(git rev-parse --show-toplevel)
+    local_path_to_git_top_abbrev=${local_path_to_git_top#$HOME/}
+    PS4="+ localhost:$local_path_to_git_top_abbrev\$ "  # to let `x` show more informative lines to stderr
     remote_workdir="${remote_repo}/${local_path_within_git#/}"
 
     # override ssh options/config

--- a/remocon
+++ b/remocon
@@ -119,7 +119,8 @@ rbc() {
     ! [[ -t 1 ]] || : ${force_color:=true}
     set -- "force_color=${force_color:-}" coloring \
         error warning info \
-        x @q rbc "$@"
+        rbc x x_prefix_for_remote @q declarationsFor in_full_tty cmdseq \
+        "$@"
     set -- "$@" "$fn"  # adding some core names to include
     local decls
     decls=$(declarationsFor "$@")

--- a/remocon
+++ b/remocon
@@ -258,7 +258,7 @@ remocon._parse_config() {
     } >&2
 
     local v
-    for v in remote{,_{host,repo,workdir}}
+    for v in remote{,_{host,repo,workdir}} PS4
     do @q "$v=${!v}"
     done
 } </dev/null

--- a/remocon
+++ b/remocon
@@ -81,7 +81,7 @@ rbc() {
     set -- x @q rbc "$@" "$fn"  # adding some core names to include
     set -- \
         "set -eu" \
-        "mkdir -p $(@q "$dir")" \
+        "mkdir -p $(@q "$workdir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "+ $hostworkdir$ ")" \
         "$(

--- a/remocon
+++ b/remocon
@@ -406,7 +406,7 @@ remocon.get() {
     fi
 } </dev/null >&2
 
-# programming round-trip mode (put-run-get)
+# programming round-trip mode (P-R-G for put, run, then get)
 remocon.prg() {
     # find which paths to get from given args
     # (NOTE path list can be terminated by a double-dash `--` to delinate the command to run)

--- a/remocon
+++ b/remocon
@@ -121,12 +121,14 @@ rbc() {
         error warning info \
         x @q rbc "$@"
     set -- "$@" "$fn"  # adding some core names to include
+    local decls
+    decls=$(declarationsFor "$@")
     set -- \
         "set -eu" \
         "mkdir -p $(@q "$workdir")" \
         "cd $(@q "$workdir")" \
         "PS4=$(@q "$(x_prefix_for_remote "$hostworkdir")")" \
-        "$(declarationsFor "$@")" \
+        "$decls" \
         "$fn"
     # determine how to run the function
     if in_full_tty; then


### PR DESCRIPTION
New `remocon get` functionality with major refactor.
- `remocon get` to do the inverse of remocon put, i.e., bringing back all changes to remote git tracked files
- `remocon get PATH...` still allows rsync'ing any remote file, not just git tracked ones
- `remocon put REMOTE...` to put to many remotes at once
- `remocon dup DST_HOST:PATH [SRC_HOST:PATH]` the underlying function now powering both get and put
- `rbc`: "remote bash call" helper function that replaces a lot of bash lines enclosed in string literals with pure bash functions that can be passed reliably by `declare -p -f`.
- reduced noisy messages and showing only important messages with color by default, with an option to further quiet: `verbose=false`.